### PR TITLE
a few more build fixes for travis, lua5.2, and python unit tests

### DIFF
--- a/src/bindings/lua/Test/Builder.lua
+++ b/src/bindings/lua/Test/Builder.lua
@@ -18,6 +18,7 @@ local tconcat = require 'table'.concat
 local tonumber = tonumber
 local tostring = tostring
 local type = type
+local table = table
 
 _ENV = nil
 local m = {}

--- a/src/bindings/python/Makefile.am
+++ b/src/bindings/python/Makefile.am
@@ -7,11 +7,6 @@ TESTS = \
 	test_commands/test_runner.t
 
 TEST_EXTENSIONS = .t
-T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
-	$(top_srcdir)/config/tap-driver.sh
-LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
-	$(top_srcdir)/config/tap-driver.sh
-
 TESTS_ENVIRONMENT = \
 	PYTHONPATH=$(top_builddir)/src/bindings/python:$(top_srcdir)/src/bindings/python/pycotap:$(top_srcdir)/src/bindings/python/:$$PYTHONPATH \
 	CHECK_BUILDDIR=$(top_builddir) \

--- a/src/test/travis-dep-builder.sh
+++ b/src/test/travis-dep-builder.sh
@@ -12,7 +12,7 @@ downloads="\
 https://github.com/dun/munge/archive/munge-0.5.11.tar.gz \
 https://download.libsodium.org/libsodium/releases/libsodium-1.0.0.tar.gz \
 http://download.zeromq.org/zeromq-4.0.4.tar.gz \
-http://download.zeromq.org/czmq-3.0.0-rc1.tar.gz \
+http://download.zeromq.org/czmq-3.0.2.tar.gz \
 https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz"
 
 declare -A extra_configure_opts=(\


### PR DESCRIPTION
This one is pretty obvious. The autoconf changes in flux-framework/flux-core#277 explicitly requires czmq-3.0.1 whereas travis always had czmq-3.0.0 prerelease. It is pretty easy to update the version travis uses so for efficiency we do that here.

However, is there a reason 3.0.0 doesn't work for flux-core?
