### PR TITLE
build: moving ldflag libs to libadd to trigger rebuilds on library updates

### DIFF
--- a/src/modules/api/Makefile.am
+++ b/src/modules/api/Makefile.am
@@ -13,9 +13,10 @@ fluxmod_libadd = \
 	$(JSON_LIBS) $(ZMQ_LIBS)
 
 fluxmod_ldflags = --disable-static -avoid-version -module -shared -export-dynamic \
-	-export-symbols-regex '^mod_(main|name)$$' \
-	$(top_builddir)/src/common/libflux-core.la
+	-export-symbols-regex '^mod_(main|name)$$'
 
 api_la_SOURCES = api.c
 api_la_LDFLAGS = $(fluxmod_ldflags)
-api_la_LIBADD = $(fluxmod_libadd)
+api_la_LIBADD = $(fluxmod_libadd) \
+	$(top_builddir)/src/common/libflux-internal.la \
+	$(top_builddir)/src/common/libflux-core.la

--- a/src/modules/barrier/Makefile.am
+++ b/src/modules/barrier/Makefile.am
@@ -12,8 +12,9 @@ fluxmod_LTLIBRARIES = barrier.la
 fluxmod_libadd = \
 	$(JSON_LIBS) $(ZMQ_LIBS)
 
-general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
-		  $(top_builddir)/src/common/libflux-internal.la \
+general_ldflags = --disable-static -avoid-version -shared -export-dynamic
+
+general_libadd = $(top_builddir)/src/common/libflux-internal.la \
 		  $(top_builddir)/src/common/libflux-core.la
 
 fluxmod_ldflags = -module -Wl,--no-undefined \
@@ -22,7 +23,7 @@ fluxmod_ldflags = -module -Wl,--no-undefined \
 
 barrier_la_SOURCES = barrier.c
 barrier_la_LDFLAGS = $(fluxmod_ldflags)
-barrier_la_LIBADD = $(fluxmod_libadd)
+barrier_la_LIBADD = $(fluxmod_libadd) $(general_libadd)
 
 #
 # API for module
@@ -31,3 +32,4 @@ fluxcoreinclude_HEADERS = barrier.h
 fluxlib_LTLIBRARIES = libbarrier.la
 libbarrier_la_SOURCES = libbarrier.c
 libbarrier_la_LDFLAGS = $(general_ldflags) 
+libbarrier_la_LIBADD = $(general_libadd) 

--- a/src/modules/kvs/Makefile.am
+++ b/src/modules/kvs/Makefile.am
@@ -34,8 +34,8 @@ libkvs_la_SOURCES = \
 	libkvs.c \
 	conf.c \
 	proto.c
-libkvs_la_LDFLAGS = -shared -export-dynamic --disable-static \
-		    $(top_builddir)/src/common/libflux-internal.la \
+libkvs_la_LDFLAGS = -shared -export-dynamic --disable-static
+libkvs_la_LIBADD =  $(top_builddir)/src/common/libflux-internal.la \
 		    $(top_builddir)/src/common/libflux-core.la
 
 #-lrt is for clock_gettime, this should be abstracted

--- a/src/modules/libjsc/Makefile.am
+++ b/src/modules/libjsc/Makefile.am
@@ -10,7 +10,7 @@ fluxcoreinclude_HEADERS = jstatctl.h
 libjsc_la_SOURCES = \
 	jstatctl.c \
 	jstatctl.h
-libjsc_la_LDFLAGS = -shared -export-dynamic --disable-static \
-          $(top_builddir)/src/modules/kvs/libkvs.la \
-          $(top_builddir)/src/common/libflux-internal.la \
-		  $(top_builddir)/src/common/libflux-core.la
+libjsc_la_LDFLAGS = -shared -export-dynamic --disable-static
+libjsc_la_LIBADD = $(top_builddir)/src/modules/kvs/libkvs.la \
+		   $(top_builddir)/src/common/libflux-internal.la \
+		   $(top_builddir)/src/common/libflux-core.la

--- a/src/modules/libmrpc/Makefile.am
+++ b/src/modules/libmrpc/Makefile.am
@@ -11,9 +11,9 @@ fluxinclude_HEADERS = \
 libmrpc_la_SOURCES = \
 	mrpc.c \
 	mrpc.h
-libmrpc_la_LDFLAGS = -shared -export-dynamic \
-		     $(top_builddir)/src/common/libflux-internal.la \
+libmrpc_la_LIBADD = $(top_builddir)/src/common/libflux-internal.la \
 		     $(top_builddir)/src/common/libflux-core.la \
-		     $(top_builddir)/src/modules/kvs/libkvs.la \
-		     $(LIBMUNGE) $(JSON_LIBS) $(ZMQ_CFLAGS) $(LIBPTHREAD) $(LIBUTIL) \
+		     $(top_builddir)/src/modules/kvs/libkvs.la
+libmrpc_la_LDFLAGS = -shared -export-dynamic \
+		     $(LIBMUNGE) $(JSON_LIBS) $(LIBZMQ) $(LIBCZMQ) $(LIBPTHREAD) $(LIBUTIL) \
 		     $(LIBDL) -lrt

--- a/src/modules/live/Makefile.am
+++ b/src/modules/live/Makefile.am
@@ -12,10 +12,12 @@ fluxmod_LTLIBRARIES = live.la
 fluxmod_libadd = \
 	$(JSON_LIBS) $(ZMQ_LIBS)
 
-general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
+general_libadd = \
 		  $(top_builddir)/src/common/libflux-internal.la \
 		  $(top_builddir)/src/common/libflux-core.la \
-		  $(top_builddir)/src/modules/kvs/libkvs.la \
+		  $(top_builddir)/src/modules/kvs/libkvs.la
+
+general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
 		  $(LIBMUNGE) $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL) \
 		  $(LIBDL) -lrt
 fluxmod_ldflags = -module \
@@ -24,7 +26,7 @@ fluxmod_ldflags = -module \
 
 live_la_SOURCES = live.c
 live_la_LDFLAGS = $(fluxmod_ldflags)
-live_la_LIBADD = $(fluxmod_libadd)
+live_la_LIBADD = $(general_libadd) $(fluxmod_libadd)
 
 #
 # API for module
@@ -32,4 +34,4 @@ live_la_LIBADD = $(fluxmod_libadd)
 fluxcoreinclude_HEADERS = live.h
 fluxlib_LTLIBRARIES = liblive.la
 liblive_la_SOURCES = liblive.c
-liblive_la_LDFLAGS = $(general_ldflags) 
+liblive_la_LDFLAGS =  $(general_libadd) $(general_ldflags)

--- a/src/modules/mecho/Makefile.am
+++ b/src/modules/mecho/Makefile.am
@@ -10,12 +10,14 @@ AM_CPPFLAGS = \
 fluxmod_LTLIBRARIES = mecho.la
 
 fluxmod_libadd = \
-	$(JSON_LIBS) $(ZMQ_LIBS)
-general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
+	$(JSON_LIBS) $(ZMQ_LIBS) \
 	$(top_builddir)/src/modules/libmrpc/libmrpc.la \
 	$(top_builddir)/src/common/libflux-core.la \
-	$(top_builddir)/src/modules/kvs/libkvs.la \
+	$(top_builddir)/src/modules/kvs/libkvs.la
+
+general_ldflags = --disable-static -avoid-version -shared -export-dynamic \
 	$(LIBMUNGE) $(JSON_LIBS) $(ZMQ_LIBS) $(LIBPTHREAD) $(LIBUTIL)
+
 fluxmod_ldflags = -module \
 	-export-symbols-regex '^mod_(main|name)$$' \
 	$(general_ldflags)


### PR DESCRIPTION
Moved in-tree libraries into LDADD so they will be checked as make dependencies on build.  Not sure I got them all, but most of the modules needed it.
