### PR TITLE
python: neutralize error check for kvsitr

### DIFF
--- a/src/bindings/python/flux/kvs.py
+++ b/src/bindings/python/flux/kvs.py
@@ -15,6 +15,8 @@ class KVSWrapper(Wrapper):
   pass
 
 _raw = KVSWrapper(ffi, lib, prefixes=['kvs', 'kvs_'])
+# override error check behavior for kvsitr_next
+_raw.kvsitr_next.set_error_check(lambda x: False)
 
 
 def get_key_direct(flux_handle, key):

--- a/src/bindings/python/flux/wrapper.py
+++ b/src/bindings/python/flux/wrapper.py
@@ -130,6 +130,9 @@ class FunctionWrapper(object):
                                     'long long', 'int32_t', 'int64_t')]:
             self.is_error = lambda x: x < 0
 
+    def set_error_check(self, fun):
+      self.is_error = fun
+
     def build_argument_translation_list(self, t):
         alist = t.args[1:] if self.add_handle else t.args
         for i, a in enumerate(alist, start=1 if self.add_handle else 0):


### PR DESCRIPTION
This commit adds a method to the FunctionWrapper class to allow users to
easily set the error checker for wrapped functions.  The same can be done with
a number of attribute transformations etc. on the wrapper, but this is a great
deal more self documenting. The new method is also used to mark the
kvsitr_next function as a cannot-fail function, since its end condition is
indistinguishable from failure.
